### PR TITLE
Note about wireplumber

### DIFF
--- a/README
+++ b/README
@@ -114,6 +114,11 @@ unload pulseaudio bluetooth modules:
   pactl unload-module module-bluez5-device
   pactl unload-module module-bluez5-discover
   pactl unload-module module-bluetooth-discover
+  
+Likewise, pipewire must be disabled:
+
+  sudo systemctl disable --global pipewire
+  sudo systemctl disable --global wireplumber
 
 After that it is possible to start hsphfpd prototype daemon implementation:
 


### PR DESCRIPTION
On Ubuntu 22, I also had to disable wireplumber. Otherwise I was faced with the message "Listening SCO socket is already open by other application, maybe broken ofono is running?"